### PR TITLE
build: exclude AppShellConfiguratorImpl class from demo-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,7 @@
 										<exclude>**/it/*</exclude>
 										<exclude>**/DemoView.class</exclude>
 										<exclude>**/DemoLayout.class</exclude>
+										<exclude>**/AppShellConfiguratorImpl.class</exclude>
 									</excludes>
 								</configuration>
 							</execution>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to exclude unnecessary class files, enhancing the efficiency of the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->