### PR TITLE
Fix javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <failOnWarnings>false</failOnWarnings>
+                            <failOnWarnings>true</failOnWarnings>
                             <links>
                                 <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>

--- a/src/main/java/com/flowingcode/vaadin/addons/chatassistant/ChatAssistant.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/chatassistant/ChatAssistant.java
@@ -318,13 +318,13 @@ public class ChatAssistant extends Div {
   }
   
   /**
-   * Scrolls to the given row index. Scrolls so that the element is shown at
+   * Scrolls to the given position. Scrolls so that the element is shown at
    * the start of the visible area whenever possible.
    * <p>
    * If the index parameter exceeds current item set size the grid will scroll
    * to the end.
    *
-   * @param rowIndex
+   * @param position
    *            zero based index of the item to scroll to in the current view.
    */
   public void scrollToIndex(int position) {


### PR DESCRIPTION
Close #28 & #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated Javadoc generation to fail on warnings, enhancing documentation quality checks.
  
- **Refactor**
	- Renamed parameter in the `scrollToIndex` method from `rowIndex` to `position` for clarity, with corresponding updates to documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->